### PR TITLE
Issue 1 - Fix message counter for each WS session not working correctly

### DIFF
--- a/internal/pkg/httpsrv/stats.go
+++ b/internal/pkg/httpsrv/stats.go
@@ -17,12 +17,16 @@ func (w *sessionStats) inc() {
 
 func (s *Server) incStats(id string) {
 	// Find and increment.
-	for _, ws := range s.sessionStats {
-		if ws.id == id {
-			ws.inc()
-			return
+	found := false
+	for i := range s.sessionStats {
+		if s.sessionStats[i].id == id {
+			s.sessionStats[i].inc()
+			found = true
+			break
 		}
 	}
-	// Not found, add new.
-	s.sessionStats = append(s.sessionStats, sessionStats{id: id, sent: 1})
+	if !found {
+		// Not found, add new.
+		s.sessionStats = append(s.sessionStats, sessionStats{id: id, sent: 1})
+	}
 }


### PR DESCRIPTION
**Why?**
issue: #1 on Readme
The server prints statistics for each WS sessioned closed but it seems to only count one message while there are more send to each WS session, e.g.

**What changed?**
Update the `incStats` method to accurately increment message counts per session.

**How to test?**
- pull the branch and run the app
- create different sessions for http://localhost:8080/goapp
- press "Open" in all the sessions you opened
- press "Close" after some time in each opened session
- Go to the terminal you used to run the app and check logs. For each session, you should see the correct number of messages that were sent until you closed the session
![Screenshot from 2024-05-19 13-14-15](https://github.com/KCh-dev/powerfactorstest/assets/60586418/a7ce517f-7bdd-4f97-a42a-74d645e61d88)






