### PR TITLE
Feature B  - Extent the API to also return the Hex value in the response

### DIFF
--- a/internal/pkg/watcher/api.go
+++ b/internal/pkg/watcher/api.go
@@ -1,7 +1,8 @@
 package watcher
 
 type Counter struct {
-	Iteration int `json:"iteration"`
+	Iteration int    `json:"iteration"`
+	Value     string `json:"value"`
 }
 
 type CounterReset struct{}

--- a/internal/pkg/watcher/watcher.go
+++ b/internal/pkg/watcher/watcher.go
@@ -35,8 +35,11 @@ func (w *Watcher) Start() error {
 		defer wg.Done()
 		for {
 			select {
-			case <-w.inCh:
+			case str := <-w.inCh:
+				w.counterLock.Lock()
 				w.counter.Iteration += 1
+				w.counter.Value = str // Set the new hex value
+				w.counterLock.Unlock()
 				select {
 				case w.outCh <- w.counter:
 				case <-w.quitChannel:


### PR DESCRIPTION
**Why?**
Feature#B on Readme
We need to extent the API to also return the Hex value in the response. 
f.x:
RESPONSE: {"iteration":1,"value":"822876EF10"}
RESPONSE: {"iteration":2,"value":"215100491D"}
RESPONSE: {"iteration":3,"value":"05DCC3B6AB"}

**What changed?**
- modified counter struct to include the value
- updated watcher to include the value

**How to test?**
- pull branch and start the app
- go to http://localhost:8080/goapp
- press "Open"
- you  should see the hex value printed along with the iteration number
![image](https://github.com/KCh-dev/powerfactorstest/assets/60586418/a7303b1e-fff6-48a8-b4ff-8bf22d2730ed)
